### PR TITLE
Fix DataBagItem reference and add proxy

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -40,6 +40,7 @@ module ChefAPI
     proxy :clients,        'Resource::Client'
     proxy :cookbooks,      'Resource::Cookbook'
     proxy :data_bags,      'Resource::DataBag'
+    proxy :data_bag_item,  'Resource::DataBagItem'
     proxy :environments,   'Resource::Environment'
     proxy :groups,         'Resource::Group'
     proxy :nodes,          'Resource::Node'

--- a/lib/chef-api/resources/data_bag.rb
+++ b/lib/chef-api/resources/data_bag.rb
@@ -36,7 +36,7 @@ module ChefAPI
         bag = new(name: name)
 
         Util.fast_collect(Dir["#{path}/*.json"]) do |item|
-          DataBagItem.from_file(item, bag)
+          Resource::DataBagItem.from_file(item, bag)
         end
       end
 


### PR DESCRIPTION
Ran into an issue with the broken class reference, and realized there wasn't a proxy for `Resource::DataBagItem` when working around the error.